### PR TITLE
fixed exception when invalid device in devicelist is requested

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
             
         ],
         "linebreak-style": [
-            "error",
+            "off",
             "unix"
         ],
         "quotes": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-zigbee2mqtt-devices",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "description": "Nodes to interact with zigbee2mqtt for Node-RED",
     "author": "Christian Dirnhofer",
     "license": "MIT",

--- a/src/_api.js
+++ b/src/_api.js
@@ -9,24 +9,29 @@ module.exports = function (RED) {
             var type = req.params.deviceType.toLowerCase();
             var vendor = decodeURI(req.params.vendor).toLowerCase();
             var model = decodeURI(req.params.model).toLowerCase();
-    
+
             res.end(JSON.stringify({
                 devices: devices.filter(e => {
-                    var dt = e.type.toLowerCase();
-                    var dv = "all";
-                    var dm = "all";
-    
-                    if (e.vendor) {
-                        dv = e.vendor.toLowerCase();
+                    try {
+                        var dt = e.type.toLowerCase();
+                        var dv = "all";
+                        var dm = "all";
+
+                        if (e.vendor) {
+                            dv = e.vendor.toLowerCase();
+                        }
+
+                        if (e.model) {
+                            dm = e.model.toLowerCase();
+                        }
+
+                        return (dt == type || (type == "enddevice" && dt == "greenpower") || (type == "all" && dt !== "coordinator")) &&
+                            (dv == vendor || (vendor == "all")) &&
+                            (dm == model || (model == "all"));
+                    } catch (err) {
+                        console.log(err);
+                        console.log(e);
                     }
-    
-                    if (e.model) {
-                        dm = e.model.toLowerCase();
-                    }
-    
-                    return (dt == type || (type == "enddevice" && dt == "greenpower") || (type == "all" && dt !== "coordinator")) &&
-                        (dv == vendor || (vendor == "all")) &&
-                        (dm == model || (model == "all"));
                 })
             }));
         } catch (err) {


### PR DESCRIPTION
there was a bug when you request a devicelist (e.g. dropdown in a genric-lamp node) a exception was thrown because of a missing property. This exception is now catched only for the invalid device (not succesfully paired but allready in the list)