### PR TITLE
Unified device-selection

### DIFF
--- a/src/_api.html
+++ b/src/_api.html
@@ -228,6 +228,7 @@
 
                     let select = $("<select></select>").attr("id", inputId).attr("style", "margin:0px 4px;");
                     let button = $("<button></button>")
+                        .attr("id", "refresh-button-" + inputId)
                         .attr("type", "button")
                         .addClass("red-ui-button")
                         .append($("<i></i>")
@@ -236,7 +237,7 @@
                         .append(" refresh");
 
                     let errorBox = $("<div></div>")
-                        .attr("id", "device-error"+ inputId)
+                        .attr("id", "device-error" + inputId)
                         .addClass("zigbee2mqtt-error-box")
                         .hide();
 
@@ -253,10 +254,25 @@
                             select.empty();
 
                             if (!data.success) {
-                                $("#device-error"+ inputId).html(data.message);
-                                $("#device-error"+ inputId).show();
+                                $("#device-error" + inputId)
+                                    .html(data.message)
+                                    .append(
+                                        $("<button></button>")
+                                            .text("Switch to manual entry")
+                                            .click(() => {
+                                                let textbox = $("<input />", { "type": "text", "value": selectedDevice });
+                                                textbox.attr("id", inputId)
+                                                    .attr("style", "margin-left: 4px;")
+                                                    .attr("placeholder", "Enter friendly_name");
+                                                $("#" + inputId).replaceWith(textbox);
+                                                $("#refresh-button-" + inputId).remove();
+                                                $("#device-error" + inputId).hide();
+                                            })
+                                    );
+
+                                $("#device-error" + inputId).show();
                             } else {
-                                $("#device-error"+ inputId).hide();
+                                $("#device-error" + inputId).hide();
                             }
 
                             select.append("<option disabled selected value> -- select an option -- </option>");

--- a/src/_api.html
+++ b/src/_api.html
@@ -196,6 +196,78 @@
 
                         $(inputId).val(selectedDevice);
                     });
+                },
+                createDeviceSelector: function (
+                    rowId,
+                    deviceName,
+                    deviceType = "all",
+                    vendor = "all",
+                    model = "all",
+                    isConfig = false,
+                    devicePropertyName = "deviceName",
+                    bridgePropertyName = "bridge"
+                ) {
+                    let inputId = `input-${devicePropertyName}`;
+                    let bridgeId = `input-bridge`;
+
+                    if (isConfig === true) {
+                        inputId = "node-config" + inputId;
+                        bridgeId = "node-config" + bridgeId;
+                    } else {
+                        inputId = "node-" + inputId;
+                        bridgeId = "node-" + bridgeId;
+                    }
+
+                    let label = $("<label></label>")
+                        .attr("for", inputId)
+                        .append(
+                            $("<i></i>")
+                                .addClass("fa")
+                                .addClass("fa-microchip"))
+                        .append(" Device");
+
+                    let select = $("<select></select>").attr("id", inputId).attr("style", "margin:0px 4px;");
+                    let button = $("<button></button>")
+                        .attr("type", "button")
+                        .addClass("red-ui-button")
+                        .append($("<i></i>")
+                            .addClass("fa")
+                            .addClass("fa-search"))
+                        .append(" refresh");
+
+                    let errorBox = $("<div></div>")
+                        .attr("id", "device-error")
+                        .addClass("zigbee2mqtt-error-box")
+                        .hide();
+
+                    $("#" + rowId)
+                        .prepend(errorBox)
+                        .prepend(button)
+                        .prepend(select)
+                        .prepend(label);
+
+                    let loadDevices = function (inputId, selectedDevice, deviceType = "all", vendor = "all", model = "all") {
+                        var bridgeId = $("#node-input-bridge").val().replace(".", "_");
+                        $.getJSON(`/z2m/devices/${bridgeId}/${deviceType}/${vendor}/${model}`, function (data) {
+                            let select = $("#" + inputId);
+                            select.empty();
+                            select.append("<option disabled selected value> -- select an option -- </option>");
+                            data.devices.forEach(e => {
+                                select.append("<option>" + e.friendly_name + "</option>");
+                            });
+
+                            select.val(selectedDevice);
+                        });
+                    }
+
+                    button.click(() => {
+                        loadDevices(inputId, deviceName, deviceType, vendor, model);
+                    });
+
+                    let bridgeIdSelector = "#" + bridgeId;
+                    $(bridgeIdSelector).change(function () {
+                        loadDevices(inputId, deviceName, deviceType, vendor, model);
+                    });
                 }
             }
         }

--- a/src/_api.html
+++ b/src/_api.html
@@ -211,8 +211,8 @@
                     let bridgeId = `input-bridge`;
 
                     if (isConfig === true) {
-                        inputId = "node-config" + inputId;
-                        bridgeId = "node-config" + bridgeId;
+                        inputId = "node-config-" + inputId;
+                        bridgeId = "node-config-" + bridgeId;
                     } else {
                         inputId = "node-" + inputId;
                         bridgeId = "node-" + bridgeId;
@@ -236,7 +236,7 @@
                         .append(" refresh");
 
                     let errorBox = $("<div></div>")
-                        .attr("id", "device-error")
+                        .attr("id", "device-error"+ inputId)
                         .addClass("zigbee2mqtt-error-box")
                         .hide();
 
@@ -246,12 +246,21 @@
                         .prepend(select)
                         .prepend(label);
 
-                    let loadDevices = function (inputId, selectedDevice, deviceType = "all", vendor = "all", model = "all") {
-                        var bridgeId = $("#node-input-bridge").val().replace(".", "_");
+                    let loadDevices = function (inputId, htmlBridgeId, selectedDevice, deviceType = "all", vendor = "all", model = "all") {
+                        var bridgeId = $("#" + htmlBridgeId).val().replace(".", "_");
                         $.getJSON(`/z2m/devices/${bridgeId}/${deviceType}/${vendor}/${model}`, function (data) {
                             let select = $("#" + inputId);
                             select.empty();
+
+                            if (!data.success) {
+                                $("#device-error"+ inputId).html(data.message);
+                                $("#device-error"+ inputId).show();
+                            } else {
+                                $("#device-error"+ inputId).hide();
+                            }
+
                             select.append("<option disabled selected value> -- select an option -- </option>");
+
                             data.devices.forEach(e => {
                                 select.append("<option>" + e.friendly_name + "</option>");
                             });
@@ -261,12 +270,12 @@
                     }
 
                     button.click(() => {
-                        loadDevices(inputId, deviceName, deviceType, vendor, model);
+                        loadDevices(inputId, bridgeId, deviceName, deviceType, vendor, model);
                     });
 
                     let bridgeIdSelector = "#" + bridgeId;
                     $(bridgeIdSelector).change(function () {
-                        loadDevices(inputId, deviceName, deviceType, vendor, model);
+                        loadDevices(inputId, bridgeId, deviceName, deviceType, vendor, model);
                     });
                 }
             }

--- a/src/_api.js
+++ b/src/_api.js
@@ -30,9 +30,14 @@ module.exports = function (RED) {
 
             response.devices = minimizeDeviceList(filterDevices(devices, type, vendor, model));
             response.success = devices.length > 0;
-            if(!response.success)
-            {
+
+            if (!response.success) {
                 response.message = "No devices found!";
+            }
+
+            if (response.success && response.devices.length == 0) {
+                response.success = false;
+                response.message = `No devices found after filtering! Used Filter: (Vendor: ${vendor}, Model: ${model}, Type: ${type})`;
             }
 
             console.log("---------------- RESPONSE -----------------");
@@ -46,8 +51,8 @@ module.exports = function (RED) {
         }
     });
 
-    function minimizeDeviceList(devices){
-        return devices.map((value)=>{
+    function minimizeDeviceList(devices) {
+        return devices.map((value) => {
             return {
                 friendly_name: value.friendly_name,
                 address: value.ieee_address,
@@ -59,11 +64,11 @@ module.exports = function (RED) {
         });
     }
 
-    function filterDevices(devices, type, vendor, model){
+    function filterDevices(devices, type, vendor, model) {
         return devices.filter(e => {
             try {
 
-                if(e.definition === undefined || e.definition === null){
+                if (e.definition === undefined || e.definition === null) {
                     return false;
                 }
 

--- a/src/nodes/devices-eurotronic.html
+++ b/src/nodes/devices-eurotronic.html
@@ -22,13 +22,12 @@
             var deviceName = node.deviceName;
             var windowSensor = node.windowSensor;
 
+            this.leberkas= "semmebresl";
+            RED.bavaria.devices.createDeviceSelector("thermnostat-selection", deviceName, "EndDevice", "Eurotronic", "SPZB0001");
+            RED.bavaria.devices.createDeviceSelector("window-selection", windowSensor, "EndDevice", "all", "all", false, "windowSensor");
+
             $("#removeSensor").click(function () {
                 document.getElementById("node-input-windowSensor").selectedIndex = -1;
-            });
-
-            $("#node-input-bridge").change(function () {
-                RED.bavaria.devices.loadDevices(deviceName, "EndDevice", "Eurotronic", "SPZB0001");
-                RED.bavaria.devices.loadDevices(windowSensor, "EndDevice", "all", "all", true, "#node-input-windowSensor");
             });
         },
         oneditsave: function () {
@@ -51,9 +50,8 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="thermnostat-selection" class="form-row">
+
         </div>
         <div class="form-row">
             <label for="node-input-mirrorDisplay"><i class="fa fa-arrows-h"></i> Mirror Display</label>
@@ -63,9 +61,7 @@
             <label for="node-input-childProtection"><i class="fa fa-lock"></i> Child Protection</label>
             <input type="checkbox" id="node-input-childProtection"/>
         </div>
-        <div class="form-row">
-            <label for="node-input-windowSensor"><i class="fa fa-microchip"></i> Window Sensor</label>
-            <select id="node-input-windowSensor"></select>
+        <div id="window-selection" class="form-row">
             <button type="button" id="removeSensor" class="red-ui-button">remove</button>
         </div>
     </div>

--- a/src/nodes/devices-ikea.html
+++ b/src/nodes/devices-ikea.html
@@ -19,18 +19,7 @@
         oneditprepare: function () {
             var node = this;
             var deviceName = node.deviceName;
-
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/endDevice/IKEA/E1743', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "EndDevice", "IKEA", "E1743");
         }
     });
 
@@ -47,9 +36,7 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="device-selection" class="form-row">
         </div>
 
     </div>

--- a/src/nodes/devices-ikea.html
+++ b/src/nodes/devices-ikea.html
@@ -96,17 +96,7 @@
             var node = this;
             var deviceName = node.deviceName;
 
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/endDevice/IKEA/E1524%2FE1810', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "EndDevice", "IKEA", "E1524%2FE1810");
         }
     });
 
@@ -123,9 +113,7 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="device-selection" class="form-row">
         </div>
 
     </div>

--- a/src/nodes/devices-ikea.html
+++ b/src/nodes/devices-ikea.html
@@ -180,18 +180,7 @@
             var node = this;
             var deviceName = node.deviceName;
 
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/endDevice/IKEA/ICTC-G-1,E1743', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "EndDevice", "IKEA", "ICTC-G-1,E1743");
         },
         oneditsave: function () {
             var outputcount = 1;
@@ -219,9 +208,7 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="device-selection" class="form-row">
         </div>
         <div class="config-group">
             <div class="form-row">

--- a/src/nodes/devices-scenic.html
+++ b/src/nodes/devices-scenic.html
@@ -19,18 +19,7 @@
         oneditprepare: function () {
             var node = this;
             var deviceName = node.deviceName;
-
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/endDevice/GreenPower/GreenPower_On_Off_Switch', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "EndDevice", "GreenPower", "GreenPower_On_Off_Switch");
         }
     });
 
@@ -47,9 +36,7 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="device-selection" class="form-row">
         </div>
 
     </div>

--- a/src/nodes/devices-sonoff.html
+++ b/src/nodes/devices-sonoff.html
@@ -19,17 +19,7 @@
             var node = this;
             var deviceName = node.deviceName;
 
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/endDevice/sonoff/SNZB-01', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "EndDevice", "sonoff", "SNZB-01");
         }
     });
 
@@ -46,9 +36,7 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="device-selection" class="form-row">
         </div>
 
     </div>

--- a/src/nodes/devices-tint.html
+++ b/src/nodes/devices-tint.html
@@ -23,17 +23,7 @@
             var node = this;
             var deviceName = node.deviceName;
 
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/endDevice/müller licht/mli-404011', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "EndDevice", "müller licht", "mli-404011");
 
             RED.bavaria.ui.addNumInput("#node-input-brightnessChange");
             RED.bavaria.ui.addNumInput("#node-input-temperatureChange");
@@ -72,9 +62,7 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="device-selection" class="form-row">
         </div>
 
         <div class="tint-remote-config-settings">

--- a/src/nodes/hue-dimmer/devices-hue.html
+++ b/src/nodes/hue-dimmer/devices-hue.html
@@ -21,17 +21,7 @@
             var node = this;
             var deviceName = node.deviceName;
 
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/endDevice/Philips/324131092621', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "EndDevice", "Philips", "324131092621");
         }
     });
 
@@ -48,9 +38,7 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
-        <div class="form-row">
-            <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
-            <select id="node-input-deviceName"></select>
+        <div id="device-selection" class="form-row">
         </div>
         
     </div>

--- a/src/zigbee2mqtt-config.html
+++ b/src/zigbee2mqtt-config.html
@@ -78,6 +78,7 @@
         oneditprepare: function () {
             var node = this;
             var deviceName = node.deviceName;
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName, "router", "all", "all", true);
 
             if (node.genericMqttDevice === true) {
                 $("#fullMqttTopic").show()
@@ -100,31 +101,6 @@
                     $("#select-empty-option").remove();
                 }
             });
-
-            $("#node-config-input-bridge").change(function () {
-                var bridgeId = $("#node-config-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/router/all/all', function (data) {
-                    $("#node-config-input-deviceName").empty();
-                    console.log(data);
-
-                    if (!data.success) {
-                        $("#device-error").html(data.message);
-                        $("#device-error").show();
-                    } else {
-                        $("#device-error").hide();
-                    }
-
-                    data.devices.forEach(e => {
-                        $("#node-config-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    if (deviceName === "---") {
-                        $("#node-config-input-deviceName").append("<option value=\"---\" id=\"select-empty-option\"> Select device </option>");
-                    }
-
-                    $("#node-config-input-deviceName").val(deviceName);
-                });
-            });
         }
     });
 </script>
@@ -136,13 +112,9 @@
     </div>	
     <div class="form-row">
         <label for="node-config-input-bridge"><i class="fa fa-tag"></i> Bridge</label>
-        <input type="text" id="node-config-input-bridge"  />
+        <input type="text" id="node-config-input-bridge" />
     </div>
-    <div class="form-row">
-        <label for="node-config-input-deviceName"><i class="fa fa-tag"></i> Device</label>
-        <select id="node-config-input-deviceName"></select>
-        <button type="button" class="red-ui-button"><i class="fa fa-search"></i> refresh</button>
-        <div id="device-error" class="zigbee2mqtt-error-box"></div>
+    <div id="device-selection" class="form-row">
     </div>
     <div class="form-row">
         <label for="node-config-input-brightnessSupport"><i class="fa fa-tag"></i> Dimmable</label>

--- a/src/zigbee2mqtt-config.ts
+++ b/src/zigbee2mqtt-config.ts
@@ -1,5 +1,3 @@
-import { throws } from "assert";
-import { type } from "jquery";
 import { NodeInitializer, NodeMessage } from "node-red";
 import {
     BridgeConfigCredentials,

--- a/src/zigbee2mqtt.html
+++ b/src/zigbee2mqtt.html
@@ -295,8 +295,6 @@
     });
 </script>
 
-
-
 <script type="text/html" data-template-name="button-switch">
     <div class="zigbee2mqtt-devices-properties">
 
@@ -403,11 +401,13 @@
         oneditprepare: function () {
             var node = this;
             var deviceName = node.deviceName;
+            
+            RED.bavaria.devices.createDeviceSelector("device-selection", deviceName);
 
             if (node.genericMqttDevice === true) {
-                $("#fullMqttTopic").show()
+                $("#fullMqttTopic").show();
             } else {
-                $("#fullMqttTopic").hide()
+                $("#fullMqttTopic").hide();
             }
 
             $("#node-input-genericMqttDevice").change(function () {
@@ -419,18 +419,6 @@
                     node.deviceName = "";
                 }
             })
-
-            $("#node-input-bridge").change(function () {
-                var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/all/all/all', function (data) {
-                    $("#node-input-deviceName").empty();
-                    data.devices.forEach(e => {
-                        $("#node-input-deviceName").append("<option>" + e.friendly_name + "</option>");
-                    });
-
-                    $("#node-input-deviceName").val(deviceName);
-                });
-            });
         }
     });
 </script>
@@ -446,9 +434,13 @@
             <label for="node-input-bridge"><i class="fa fa-server"></i> Bridge</label>
             <input type="text" id="node-input-bridge" placeholder="bridge" />
         </div>
+        <!--
         <div class="form-row">
             <label for="node-input-deviceName"><i class="fa fa-microchip"></i> Device</label>
             <select id="node-input-deviceName"></select>
+        </div>-->
+        <div id="device-selection" class="form-row">
+
         </div>
         <div class="form-row">
             <label for="node-input-genericMqttDevice"><i class="fa fa-tag"></i> Generic MQTT Device</label>

--- a/upcomming-changelog.md
+++ b/upcomming-changelog.md
@@ -17,6 +17,7 @@
 
 - Deployment increased the refresh messages that will be sent on deployment. Fixes #45
 - Redone the device-list as payload has changed and this topic is now also retained on the mqtt broker. It should solve #32
+
 #### Behind the scenes
 
-
+- Unified device-selection. Resolved #69

--- a/upcomming-changelog.md
+++ b/upcomming-changelog.md
@@ -12,7 +12,7 @@
 - Removed custom MQTT Configuration and replaced it with the MQTT Configuration from the core nodes
 - Added option to `bridge-config` to disable device refresh on deployment
 - Added option to `bridge-config` to log log-messages from zigbee2mqtt to the `debug tab`
-- Added fallback-option to `device-selection`. If no devices are found you can now switch the list to a textbox and the the `friendly_name` manually. Resolves #71.
+- Added fallback-option to `device-selection`. If no devices are found you can now switch the list to a textbox and type the `friendly_name` manually. Resolves #71.
 
 #### Bug fixes:
 

--- a/upcomming-changelog.md
+++ b/upcomming-changelog.md
@@ -12,6 +12,7 @@
 - Removed custom MQTT Configuration and replaced it with the MQTT Configuration from the core nodes
 - Added option to `bridge-config` to disable device refresh on deployment
 - Added option to `bridge-config` to log log-messages from zigbee2mqtt to the `debug tab`
+- Added fallback-option to `device-selection`. If no devices are found you can now switch the list to a textbox and the the `friendly_name` manually. Resolves #71.
 
 #### Bug fixes:
 


### PR DESCRIPTION
This resolves #69 

In addition I added a fallback-option to `device-selection`. If no devices are found you can now switch the list to a textbox and type the `friendly_name` manually. Resolves #71.