### PR TITLE
Fix: removed mqtt-config node from package as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
             "devices-tint": "dist/nodes/devices-tint.js",
             "generic-lamp": "dist/zigbee2mqtt.js",
             "non-z2m-devices-shelly-25": "dist/non-z2m-nodes/devices-shelly-25.js",
-            "mqtt-config": "dist/non-z2m-nodes/mqtt-config.js",
             "ota": "dist/ota.js",
             "override": "dist/nodes/override/override-nodes.js",
             "scenes": "dist/nodes/scenes.js",


### PR DESCRIPTION
Just saw that my production system shows an error after it is installed that the config is not there.

![image](https://user-images.githubusercontent.com/13376471/105058918-07004b80-5a77-11eb-88d8-cbb5db696aad.png)

I don't think that it has any impact? But maybe explains the behavior I experienced that I have to delete the nodes manually. Hard maybe on that guess.
Shall we release for that?