### PR TITLE
Remove eslintrc, dashboard and resources from the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,6 @@ _template.html
 _template.js
 upcomming-changelog.md
 docs/
+.eslintrc.js
+dashboard/
+resources/

--- a/upcoming-changelog.md
+++ b/upcoming-changelog.md
@@ -10,3 +10,4 @@
 #### Bug fixes:
 
 #### Behind the scenes
+- Removed some unnecessary files from the package, reducing the size from 324 kB to 229 kB


### PR DESCRIPTION
**Added a `.npmignore`, because I noticed we distribute some unnecessary files.**
Priority low, no release required.

Screenshot with the unnecessary files, from the node_modules folder:

![image](https://user-images.githubusercontent.com/13376471/106177875-5d693a80-6199-11eb-926b-a0eebbd9afc3.png)

**The package got smaller:**
Size before:
package size:  91.4 kB                                        
unpacked size: 323.6 kB 

Size after:
package size:  39.8 kB                                        
unpacked size: 229.3 kB   

@Dirnei removing the dashboard and the logo was the right thing to do - since they are not used?
BTW: I also renamed the upcoming changelog, because there was a typo in the file name.