### PR TITLE
Getting Started: documented additional settings for mosquitto 2.0

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,12 +141,14 @@ If you have a bit of money to spend, we suggest the [Texas Instruments LAUNCHXL-
     andreas@nuc:~/smarthome$ nano mosquitto/config/mosquitto.conf
     ```
 
-    Paste this configuration to define the logging and persistence locations.
+    Paste this configuration to define the logging and persistence locations, the port to listen to on any interface. Furthermore, this enables anonymous authentication to keep this tutorial simple. Mosquitto provides multiple [authentication methods](https://mosquitto.org/documentation/authentication-methods/) for production systems.
 
-    ```
+    ```    
     persistence true
     persistence_location /mosquitto/data/
     log_dest file /mosquitto/log/mosquitto.log
+    listener 1883
+    allow_anonymous true
     ```
 
 4. **Create and run the Docker containers**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,7 +141,7 @@ If you have a bit of money to spend, we suggest the [Texas Instruments LAUNCHXL-
     andreas@nuc:~/smarthome$ nano mosquitto/config/mosquitto.conf
     ```
 
-    Paste this configuration to define the logging and persistence locations, the port to listen to on any interface. Furthermore, this enables anonymous authentication to keep this tutorial simple. Mosquitto provides multiple [authentication methods](https://mosquitto.org/documentation/authentication-methods/) for production systems.
+    Paste this configuration to define the logging and persistence locations. It is pre-configured to listen to the default port on any interface in the container. Furthermore, this enables anonymous authentication to keep this tutorial simple. Mosquitto provides multiple [authentication methods](https://mosquitto.org/documentation/authentication-methods/) for production systems.
 
     ```    
     persistence true

--- a/upcoming-changelog.md
+++ b/upcoming-changelog.md
@@ -8,5 +8,6 @@
 #### Features:
 
 #### Bug fixes:
+- Documented additional settings for upgrading to mosquitto 2.0 in the getting started guide.
 
 #### Behind the scenes


### PR DESCRIPTION
The mosquitto 2.0 release changed some default behaviors, so the default configuration in the getting started guide did not work anymore.

In summary, anonymous authentication has to be specified explicitly and a listener to the port (for all interfaces) has to be specified, otherwise it is just accessible from within the container.
https://mosquitto.org/documentation/migrating-to-2-0/

Resolves #107 