### PR TITLE
Hotfix/nodered crash hue undefined action

### DIFF
--- a/src/nodes/devices-scenic.js
+++ b/src/nodes/devices-scenic.js
@@ -12,6 +12,11 @@ module.exports = function (RED) {
         const regId = bavaria.observer.register(bridgeNode.id + "_connected", function (message) {
             node.status({ fill: "green", text: "connected" });
             bridgeNode.subscribeDevice(node.id, config.deviceName, function (message) {
+                if (message.action === undefined || message.action === "") {
+                    // Ignore message with empty action
+                    return;
+                }
+
                 var ioMap = {
                     recall_scene_0: utils.createButtonOutput(0, "A0", "pressed"),
                     recall_scene_4: utils.createButtonOutput(0, "A0", "released"),

--- a/src/nodes/devices-sonoff.js
+++ b/src/nodes/devices-sonoff.js
@@ -12,7 +12,8 @@ module.exports = function (RED) {
             node.status({ fill: "green", text: "connected" });
             bridgeNode.subscribeDevice(node.id, config.deviceName, function (message) {
                 try {
-                    if (message.action === undefined) {
+                    if (message.action === undefined || message.action === "") {
+                        // Ignore message with empty action
                         return;
                     }
 

--- a/src/nodes/hue-dimmer/devices-hue.js
+++ b/src/nodes/hue-dimmer/devices-hue.js
@@ -11,9 +11,11 @@ module.exports = function (RED) {
         const regId = bavaria.observer.register(bridgeNode.id + "_connected", function (message) {
             node.status({ fill: "green", text: "connected" });
             bridgeNode.subscribeDevice(node.id, config.deviceName, function (message) {
-                if (typeof message.action === 'undefined') {
+                if (message.action === undefined || message.action === "" ||  message.action === 'undefined') {
+                    // Ignore message with empty action
                     return;
                 }
+                
                 message.action = message.action.split("-").join("_");
 
                 const ioMap = {};

--- a/src/nodes/hue-dimmer/devices-hue.js
+++ b/src/nodes/hue-dimmer/devices-hue.js
@@ -11,7 +11,7 @@ module.exports = function (RED) {
         const regId = bavaria.observer.register(bridgeNode.id + "_connected", function (message) {
             node.status({ fill: "green", text: "connected" });
             bridgeNode.subscribeDevice(node.id, config.deviceName, function (message) {
-                if (message.action === undefined || message.action === "" ||  message.action === 'undefined') {
+                if (message.action === undefined || message.action === "") {
                     // Ignore message with empty action
                     return;
                 }

--- a/upcoming-changelog.md
+++ b/upcoming-changelog.md
@@ -1,15 +1,17 @@
-# Changelog for the upcomming version
-> This document is an internal note for the changelog of the upcomming release.
+# Changelog for the upcoming version
+> This document is an internal note for the changelog of the upcoming release.
 
 > If new features are added, increase the minor version || if bug fixes are added, increase the patch version.
 
 ### Release: `0.19.3`
 
 #### Features:
-- Documented additional settings for upgrading to mosquitto 2.0 in the getting started guide.
+- Documented additional settings for upgrading to mosquito 2.0 in the getting started guide.
 - Documented Mirek scale. 
 
 #### Bug fixes:
 - Not set property on Ikea Remote device caused a complete Node-Red restart
+- Not set property on Hue Remote device caused a complete Node-Red restart
+- Preventive measure: Check action for empty string in scenic remote and sonnoff buttons
 
 #### Behind the scenes

--- a/upcoming-changelog.md
+++ b/upcoming-changelog.md
@@ -6,7 +6,7 @@
 ### Release: `0.19.3`
 
 #### Features:
-- Documented additional settings for upgrading to mosquito 2.0 in the getting started guide.
+- Documented additional settings for upgrading to mosquitto 2.0 in the getting started guide.
 - Documented Mirek scale. 
 
 #### Bug fixes:


### PR DESCRIPTION
Not setting property on Hue Remote device caused a complete Node-Red restart.
The property was checked for a string containing 'undefined' not undefined.
Fixes #93 


Also as a preventive measure, I implemented to check the action for an empty string in the scenic remote and sonnoff buttons.