### PR TITLE
Fixed failed to load device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 debug
 node_modules
 dist
+node-red-contrib-zigbee2mqtt-devices*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,5 @@ docs/
 .eslintrc.js
 dashboard/
 resources/
+node-red-contrib-zigbee2mqtt-devices*.tgz
+CONTRIBUTING.md

--- a/src/_api.html
+++ b/src/_api.html
@@ -189,7 +189,7 @@
             devices: {
                 loadDevices: function (selectedDevice, deviceType, vendor, model, emptyOption = false, inputId = "#node-input-deviceName") {
                     var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                    $.getJSON(`/z2m/devices/${bridgeId}/${deviceType}/${vendor}/${model}`, function (data) {
+                    $.getJSON(`z2m/devices/${bridgeId}/${deviceType}/${vendor}/${model}`, function (data) {
                         $(inputId).empty();
                         if (emptyOption === true) {
                             $(inputId).append("<option disabled selected value> -- select an option -- </option>");
@@ -254,7 +254,7 @@
 
                     let loadDevices = function (inputId, htmlBridgeId, selectedDevice, deviceType = "all", vendor = "all", model = "all") {
                         var bridgeId = $("#" + htmlBridgeId).val().replace(".", "_");
-                        $.getJSON(`/z2m/devices/${bridgeId}/${deviceType}/${vendor}/${model}`, function (data) {
+                        $.getJSON(`z2m/devices/${bridgeId}/${deviceType}/${vendor}/${model}`, function (data) {
                             let select = $("#" + inputId);
                             select.empty();
 

--- a/src/nodes/scenes.html
+++ b/src/nodes/scenes.html
@@ -82,7 +82,7 @@
     }
 
     function refreshScenes() {
-        $.getJSON(window.location.pathname + 'z2m/scenes', function (data) {
+        $.getJSON('z2m/scenes', function (data) {
             var selection = getSelection();
 
             var scenes = data.scenes.filter(f => {

--- a/src/ota.html
+++ b/src/ota.html
@@ -22,7 +22,7 @@
             var node = this;
             $("#node-input-bridge").change(function () {
                 var bridgeId = $("#node-input-bridge").val().replace(".", "_");
-                $.getJSON(window.location.pathname + 'z2m/devices/' + bridgeId + '/Router/all/all', function (data) {
+                $.getJSON('z2m/devices/' + bridgeId + '/Router/all/all', function (data) {
                     $("#node-input-deviceName").empty();
                     data.devices.forEach(e => {
                         $("<option/>").val(e.friendly_name).text(e.friendly_name).appendTo("#node-input-deviceName");

--- a/upcoming-changelog.md
+++ b/upcoming-changelog.md
@@ -3,15 +3,12 @@
 
 > If new features are added, increase the minor version || if bug fixes are added, increase the patch version.
 
-### Release: `0.19.3`
+### Release: `0.19.5`
 
 #### Features:
-- Documented additional settings for upgrading to mosquitto 2.0 in the getting started guide.
-- Documented Mirek scale. 
+
 
 #### Bug fixes:
-- Not set property on Ikea Remote device caused a complete Node-Red restart
-- Not set property on Hue Remote device caused a complete Node-Red restart
-- Preventive measure: Check action for empty string in scenic remote and sonnoff buttons
+- Hosting the Node-RED UI under a different root path than `http://localhost:1880/` resulted in failing web requests to load the device list. For example, when the UI was set to `http://localhost:1880/admin` or Node-RED was running as a Home Assistant plugin.
 
 #### Behind the scenes


### PR DESCRIPTION
### Fixed failed to the load device list when Node-RED UI hosted on non-default URL. 

Running the Node-RED admin interface on another URL seems relatively common. The root URL can easily be changed within the Node-RED `settings.js` file.
``` javascript
/** By default, the Node-RED UI is available at http://localhost:1880/
* The following property can be used to specify a different root path.
 * If set to false, this is disabled.
*/
httpAdminRoot: '/admin',
```

But our requests from the front end failed, as we did not consider this possibility. This pull request fixes this problem by making the URLs relative and most importantly testing the current and desired behavior.

**I tested various URLs with a Standalone NodeRED installation:**
`http://localhost:1880/`
`http://localhost:1880/admin`
`http://localhost:1880/test/editor`

**I also tested it within Home Assistant as suggested in Issue #105:**
`http://homeassistant.local:8123/a0d7b954_nodered/dashboard`

All those URLs work now.

###  Why did we make this mistake in the first place?
Node-RED uses express to host the admin interface. When listening to a get request we use what seems to be an absolute URL. Using a relative URL `z2m/devices/...` does not work with express - the request will return result in a 404 response. So probably we assumed it only works with absolute URLs. I looked a bit into express. As it turns out even though the URL starts with a `/` prefix, it is always relative to the application or route.
For us that means, when the admin interface and therefore the admin express application is set to listen to `/admin`, calls to the requests as specified below will be received under `/admin/z2m/devices/...`.

``` javascript
// file: _api.js
module.exports = function (RED) {
    const utils = require("./lib/utils.js");

    // This URL is relative to the httpAdmin express application
    RED.httpAdmin.get("/z2m/devices/:broker/:deviceType/:vendor/:model", function (req, res) {
        try {
            var response = {
                success: false,
                message: "",
                devices: []
            };
            ...
```

The only necessary change was, to make the web requests relative to the admin interface and not absolute. Since the admin interface is a single-page application that only uses anchors for the flows, making requests to `z2m/devices` fixes the problem.

I also had a look at how this kind of configuration requests are done in the [node-red/node-red-nodes](https://github.com/node-red/node-red-nodes) and they implemented it as I did now.

### Issues
- This fixes issue #105 partially. The failing manual device setting is not addressed yet - but should in theory not be necessary anymore.
- Schou and simbloke reported the same issue on the discord server
- Issue #47 tried to address this correctly but apparently did not solve the problem everywhere