### PR TITLE
Fix bridge config connection

### DIFF
--- a/src/zigbee2mqtt-config.ts
+++ b/src/zigbee2mqtt-config.ts
@@ -172,7 +172,20 @@ const nodeInit: NodeInitializer = (RED): void => {
         }
 
         this.subscribe(node.id, `${config.baseTopic}/bridge/state`, (message) => {
-            if (message === "online") {
+            
+            function getState(message : any){
+                try {
+                    // In newer versions the state topic has an object with a state property
+                    const messageObj = JSON.parse(message);
+                    return messageObj.state;
+                } catch (e) {
+                    // Backwards compability: in previous versions the state topic was just a string "online"
+                    return message;   
+                }
+            }
+            
+            const state = getState(message);
+            if (state === "online") {
                 bavaria.observer.notify(node.id + "_connected");
             }
         }, false);

--- a/upcoming-changelog.md
+++ b/upcoming-changelog.md
@@ -3,10 +3,11 @@
 
 > If new features are added, increase the minor version || if bug fixes are added, increase the patch version.
 
-### Release: `0.20.0`
+### Release: `0.19.6`
 
 #### Features:
 
 #### Bug fixes:
+- Bridge did not connect in newer z2m versions, because z2m changed the format of 'bridge/state' froms string to JSON.
 
 #### Behind the scenes


### PR DESCRIPTION
Bridge did not connect in newer z2m versions because z2m changed the format of `bridge/state` from string to JSON. This had an impact on other nodes such as the climate sensor.

Fixes #126 

The state is shown correctly after fix:
![image](https://user-images.githubusercontent.com/13376471/197414388-1827f835-e3b6-400a-bb4b-4db5064598e9.png)
