### PR TITLE
Support *_press_release actions for Hue dimmer

### DIFF
--- a/src/nodes/hue-dimmer/devices-hue.js
+++ b/src/nodes/hue-dimmer/devices-hue.js
@@ -31,8 +31,17 @@ module.exports = function (RED) {
                 ioMap["down_press"] = utils.createButtonOutput(3, "down", "pressed");
                 ioMap["down_hold"] = utils.createButtonOutput(3, "down", "hold");
                 ioMap["down_hold_release"] = utils.createButtonOutput(3, "down", "released");
+		ioMap["on_press_release"]   = utils.createButtonOutput(0,"on","released");
+		ioMap["off_press_release"]  = utils.createButtonOutput(1,"off","released");
+		ioMap["up_press_release"]   = utils.createButtonOutput(2,"up","released");
+		ioMap["down_press_release"] = utils.createButtonOutput(3,"down","released");
 
                 var output = ioMap[message.action];
+
+		if (!output) {
+  			node.warn(`Unhandled action: ${message.action}`);
+  			return;
+		}
                 utils.sendAt(node, output.index, {
                     payload: {
                         button_name: output.button_name,


### PR DESCRIPTION
This PR adds support for *_press_release actions emitted by Philips Hue Dimmer Switch when paired in Zigbee2MQTT.

These actions (e.g., up_press_release, on_press_release) are not currently mapped in the Hue Dimmer node, which causes messages to be silently ignored or cause runtime errors (when output.index is accessed on undefined):

6 Jul 21:21:31 - [red] Uncaught Exception:
6 Jul 21:21:31 - [error] TypeError: Cannot read properties of undefined (reading 'index')
    at MqttSubscription.callback (/data/node_modules/node-red-contrib-zigbee2mqtt-devices/dist/nodes/hue-dimmer/devices-hue.js:32:43)
    at MqttSubscription.invokeIfMatch (/data/node_modules/node-red-contrib-zigbee2mqtt-devices/dist/lib/mqtt.js:28:18)
    at /data/node_modules/node-red-contrib-zigbee2mqtt-devices/dist/zigbee2mqtt-config.js:33:25
    at Array.forEach (<anonymous>)
    at Object.callback (/data/node_modules/node-red-contrib-zigbee2mqtt-devices/dist/zigbee2mqtt-config.js:32:36)
    at subscription.handler (/usr/src/node-red/node_modules/@node-red/nodes/core/network/10-mqtt.js:1082:67)
    at MqttClient.emit (node:events:536:35)
    at handlePublish (/usr/src/node-red/node_modules/mqtt/build/lib/handlers/publish.js:97:20)
    at handle (/usr/src/node-red/node_modules/mqtt/build/lib/handlers/index.js:28:35)
    at work (/usr/src/node-red/node_modules/mqtt/build/lib/client.js:221:40)
    

It seems that latest Zigbee2MQTT changed the event data that Hue Dimmers publish causing an incompatibility to the existing 
node-red-contrib-zigbee2mqtt-devices lib.

Tested with
Zigbee2MQTT v2.3.0
Philips Hue Dimmer switch (not v2, older version)
Node-RED with node-red-contrib-zigbee2mqtt-devices v0.20.0
