### PR TITLE
Updates docker-compose command

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "createnode:win32": "@powershell -NoProfile -Command ./createNode.ps1",
         "lint": "eslint ./src/**/*.js ./test/**/*.js ./test-integration/**/*.js",
         "test": "mocha \"test/**/*_spec.js\"",
-        "testintegration": "docker-compose -f  test-integration/docker/docker-compose.yml up -d && mocha \"test-integration/**/*_spec.js\""
+        "testintegration": "docker compose -f  test-integration/docker/docker-compose.yml up -d && mocha \"test-integration/**/*_spec.js\""
     },
     "devDependencies": {
         "@types/jquery": "^3.5.13",


### PR DESCRIPTION
The command `docker-compose` is deprecated, so it changes the command to `docker compose` to align with newer versions.